### PR TITLE
bigtools: Recipe fixes

### DIFF
--- a/recipes/bigtools/build.sh
+++ b/recipes/bigtools/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -ex
+
+# Add workaround for SSH-based Git connections from Rust/cargo.  See https://github.com/rust-lang/cargo/issues/2078 for details.
+# We set CARGO_HOME because we don't pass on HOME to conda-build, thus rendering the default "${HOME}/.cargo" defunct.
+export CARGO_NET_GIT_FETCH_WITH_CLI=true CARGO_HOME="${BUILD_PREFIX}/.cargo"
+export RUST_BACKTRACE=full
+
+cargo install --verbose --path . --root $PREFIX --locked
+

--- a/recipes/bigtools/build.sh
+++ b/recipes/bigtools/build.sh
@@ -6,5 +6,5 @@ set -ex
 export CARGO_NET_GIT_FETCH_WITH_CLI=true CARGO_HOME="${BUILD_PREFIX}/.cargo"
 export RUST_BACKTRACE=full
 
-cargo install --verbose --path . --root $PREFIX --locked
+cargo install --verbose --path ./bigtools --root $PREFIX --locked
 

--- a/recipes/bigtools/meta.yaml
+++ b/recipes/bigtools/meta.yaml
@@ -1,5 +1,4 @@
 {% set version = "0.4.1" %}
-{% set sha256 = "....." %}
 
 package:
   name: bigtools
@@ -11,8 +10,8 @@ build:
     - {{ pin_subpackage('bigtools', max_pin="x.x") }}
 
 source:
-  url: https://github.com/jack726/bigtools/refs/tags/v{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://github.com/jackh726/bigtools/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: "92b9ea165adb1f9b13222d6c78e12148d9ba04a0d6ae96001820d43d9af7b39e"
 
 requirements:
   build:
@@ -24,7 +23,7 @@ test:
     - bigtools --help | grep Usage
 
 about:
-  home: https://github.com/jack726/bigtools/
+  home: https://github.com/jackh726/bigtools/
   license: MIT
   doc_url: https://docs.rs/bigtools/latest/bigtools/
   summary: 'Bigtools provides a high-level, performant API for reading and writing bigWig and bigBed files.'

--- a/recipes/pybigtools/build.sh
+++ b/recipes/pybigtools/build.sh
@@ -11,7 +11,7 @@ if [ `uname` == Darwin ]; then
 fi
 
 # Build the package using maturin - should produce *.whl files.
-maturin build --interpreter $PYTHON --release
+maturin build -m pybigtools/Cargo.toml --interpreter $PYTHON --release
 
 # Install *.whl files using pip
-$PYTHON -m pip install target/wheels/*.whl --no-deps --ignore-installed -vv
+$PYTHON -m pip install target/wheels/*.whl --no-deps --ignore-instialled -vv

--- a/recipes/pybigtools/build.sh
+++ b/recipes/pybigtools/build.sh
@@ -14,4 +14,4 @@ fi
 maturin build -m pybigtools/Cargo.toml --interpreter $PYTHON --release
 
 # Install *.whl files using pip
-$PYTHON -m pip install target/wheels/*.whl --no-deps --ignore-instialled -vv
+$PYTHON -m pip install target/wheels/*.whl --no-deps --ignore-installed -vv

--- a/recipes/pybigtools/meta.yaml
+++ b/recipes/pybigtools/meta.yaml
@@ -1,13 +1,12 @@
 {% set version = "0.1.0" %}
-{% set sha256 = "....." %}
 
 package:
   name: pybigtools
   version: {{ version }}
 
 source:
-  url: https://github.com/jack726/bigtools/refs/tags/pybigtools@v{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://github.com/jackh726/bigtools/archive/refs/tags/pybigtools@v{{ version }}.tar.gz
+  sha256: "bb1a1f1d1f39ce0b73eafb40e291b1ded26fbb283898371ade3414c008b80cdf"
 
 build:
   number: 0
@@ -29,7 +28,7 @@ test:
     - pybigtools
 
 about:
-  home: https://github.com/jack726/bigtools/
+  home: https://github.com/jackh726/bigtools/
   license: MIT License
   summary: 'pybigtools: Python bindings to the Bigtools Rust library for high-performance BigWig and BigBed I/O'
   license_family: MIT


### PR DESCRIPTION
* Fixed URLs and added sha256 hashes
* Added build.sh for bigtools
* Fixed build paths for cargo and maturin